### PR TITLE
Changed README to reflect GetObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ await BlobCache.UserAccount.InsertObject("toaster", myToaster);
 //
 
 // Using async/await
-var toaster = await BlobCache.UserAccount.GetObjectAsync<Toaster>("toaster");
+var toaster = await BlobCache.UserAccount.GetObject<Toaster>("toaster");
 
 // or without async/await
 Toaster toaster;
 
-BlobCache.UserAccount.GetObjectAsync<Toaster>("toaster")
+BlobCache.UserAccount.GetObject<Toaster>("toaster")
     .Subscribe(x => toaster = x, ex => Console.WriteLine("No Key!"));
 ```
 


### PR DESCRIPTION
If I'm not wrong GetObjectAsync is no longer part of Akavache:
https://github.com/akavache/Akavache/search?utf8=%E2%9C%93&q=GetObjectAsync

The extension method also does not appear in the VS Object Browser.

It only seems to exist in the README.