### PR TITLE
Update the SQlite instructions in the README for the .NET desktop platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ added to support:
 
 * **Xamarin.Android** - No issues.
 
-* **.NET 4.5 Desktop (WPF)** - You must mark your application as `x86`, or else
-  you will get a strange runtime error about SQLitePCL_Raw not loading correctly.
+* **.NET 4.5 Desktop (WPF)** - No issues
 
 * **Windows Phone 8.0** - You must mark your application as `x86` or `ARM`, or
   else you will get a strange runtime error about SQLitePCL_Raw not loading


### PR DESCRIPTION
As of https://github.com/ericsink/SQLitePCL.raw/commit/1081160c1e5dc75eefab04dd1eb5cf825864aca7, SQLitePCL.raw creates an x86 and x64 folder in the app build output and switches to the appropriate SQLite library at runtime, so users of the .NET 4.5 platform can target AnyCPU