### PR TITLE
Fix vacuum

### DIFF
--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -245,6 +245,7 @@ namespace Akavache.Sqlite3
                 }
             })
             .ToObservable()
+            .ObserveOn(scheduler)
             .Multicast(ret)
             .PermaRef();
 

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -32,6 +32,7 @@ namespace Akavache.Sqlite3
         readonly BulkInvalidateByTypeSqliteOperation bulkInvalidateType;
         readonly InvalidateAllSqliteOperation invalidateAll;
         readonly VacuumSqliteOperation vacuum;
+        readonly DeleteExpiredSqliteOperation deleteExpired;
         readonly GetKeysSqliteOperation getAllKeys;
         readonly BeginTransactionSqliteOperation begin;
         readonly CommitTransactionSqliteOperation commit;
@@ -50,6 +51,7 @@ namespace Akavache.Sqlite3
             bulkInvalidateType = new BulkInvalidateByTypeSqliteOperation(conn);
             invalidateAll = new InvalidateAllSqliteOperation(conn);
             vacuum = new VacuumSqliteOperation(conn, scheduler);
+            deleteExpired = new DeleteExpiredSqliteOperation(conn, scheduler);
             getAllKeys = new GetKeysSqliteOperation(conn, scheduler);
             begin = new BeginTransactionSqliteOperation(conn);
             commit = new CommitTransactionSqliteOperation(conn);
@@ -258,6 +260,9 @@ namespace Akavache.Sqlite3
                     case OperationType.InvalidateAllSqliteOperation:
                         MarshalCompletion(item.Completion, invalidateAll.PrepareToExecute(), commitResult);
                         break;
+                    case OperationType.DeleteExpiredSqliteOperation:
+                        MarshalCompletion(item.Completion, deleteExpired.PrepareToExecute(), commitResult);
+                        break;
                     case OperationType.VacuumSqliteOperation:
                         commit.PrepareToExecute()();
                         MarshalCompletion(item.Completion, vacuum.PrepareToExecute(), commitResult);
@@ -330,7 +335,7 @@ namespace Akavache.Sqlite3
         {
             var toDispose = new IDisposable[] {
                 bulkSelectKey, bulkSelectType, bulkInsertKey, bulkInvalidateKey,
-                bulkInvalidateType, invalidateAll, vacuum, getAllKeys, begin, 
+                bulkInvalidateType, invalidateAll, vacuum, deleteExpired, getAllKeys, begin, 
                 commit,
             };
 

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -259,7 +259,9 @@ namespace Akavache.Sqlite3
                         MarshalCompletion(item.Completion, invalidateAll.PrepareToExecute(), commitResult);
                         break;
                     case OperationType.VacuumSqliteOperation:
+                        commit.PrepareToExecute()();
                         MarshalCompletion(item.Completion, vacuum.PrepareToExecute(), commitResult);
+                        begin.PrepareToExecute()();
                         break;
                     default:
                         throw new ArgumentException("Unknown operation");

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -217,8 +217,8 @@ namespace Akavache.Sqlite3
         {
             // Vacuum is a special snowflake. We want to delete all the expired rows before
             // actually vacuuming. Unfortunately vacuum can't be run in a transaction so we'll
-            // do the delete first, then claim an exclusive lock on the queue, drain it and
-            // run our vacuum op without any transactions.
+            // claim an exclusive lock on the queue, drain it and run the delete first before
+            // running our vacuum op without any transactions.
             var ret = new AsyncSubject<Unit>();
 
             Task.Run(async () =>

--- a/Akavache.Sqlite3/OperationQueueCoalescing.cs
+++ b/Akavache.Sqlite3/OperationQueueCoalescing.cs
@@ -253,6 +253,7 @@ namespace Akavache.Sqlite3
                 case OperationType.GetKeysSqliteOperation:
                 case OperationType.InvalidateAllSqliteOperation:
                 case OperationType.VacuumSqliteOperation:
+                case OperationType.DeleteExpiredSqliteOperation:
                 case OperationType.DoNothing:
                     return default(string);
                 default:


### PR DESCRIPTION
Vacuum is broken in Akavache.Sqlite3 most likely going back to 4.0.0. There's two issues at play. 

One is that you can't have multiple statements in a prepared statement so the ```VACUUM``` statement was never been executed, only the ```DELETE```. Second, the ```VACUUM``` statement [can't be run within a transaction](https://sqlite.org/lang_vacuum.html) which is a problem since Akavache wraps everything in a transaction.

This is a first PoC solution which splits the vacuum operation into two statements that are run sequentially. Because of the transaction limitation we commit the transaction right the vacuum and then start it up again after. This will very likely have unintended side-effects but it's a proof that this is what's going on.