### PR TITLE
Prevents caches that were never used being created as side effect of BlobCache.Shutdown()

### DIFF
--- a/Akavache/Portable/BlobCache.cs
+++ b/Akavache/Portable/BlobCache.cs
@@ -231,7 +231,13 @@ namespace Akavache
                     return Observable.Return(Unit.Default);
                 }
             }
-            public IScheduler Scheduler { get; }
+            public IScheduler Scheduler
+            {
+                get
+                {
+                    return null;
+                }
+            }
         }
     }
 }

--- a/Akavache/Portable/BlobCache.cs
+++ b/Akavache/Portable/BlobCache.cs
@@ -235,7 +235,7 @@ namespace Akavache
             {
                 get
                 {
-                    return null;
+                    return System.Reactive.Concurrency.Scheduler.Immediate;
                 }
             }
         }

--- a/Akavache/Portable/BlobCache.cs
+++ b/Akavache/Portable/BlobCache.cs
@@ -224,19 +224,12 @@ namespace Akavache
                 return null;
             }
 
-            IObservable<Unit> IBlobCache.Shutdown
-            {
-                get
-                {
-                    return Observable.Return(Unit.Default);
-                }
+            IObservable<Unit> IBlobCache.Shutdown {
+                get { return Observable.Return(Unit.Default); }
             }
-            public IScheduler Scheduler
-            {
-                get
-                {
-                    return System.Reactive.Concurrency.Scheduler.Immediate;
-                }
+
+            public IScheduler Scheduler {
+                get { return System.Reactive.Concurrency.Scheduler.Immediate; }
             }
         }
     }


### PR DESCRIPTION
Fixes issue #192.

Adding a null "ShutdownBlobCache" that can be used to prevent caches that were never used from being created upon BlobCache.Shutdown().  I set a static bool when Shutdown is called, then add a check of that bool to the null coalescing chain before a new instance would be created.

Please be kind, this is my first pull request on any project EVER.  