### PR TITLE
Fix deadlock in flush and vacuum

### DIFF
--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -143,7 +143,11 @@ namespace Akavache.Sqlite3
                 } 
                 catch (OperationCanceledException) { }
 
-                FlushInternal();
+                using (flushLock.LockAsync().Result)
+                {
+                    FlushInternal();
+                }
+
                 start = null;
             }));
         }

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -300,6 +300,7 @@ namespace Akavache.Sqlite3
                 switch (item.OperationType)
                 {
                     case OperationType.DoNothing:
+                        MarshalCompletion(item.Completion, () => { }, commitResult);
                         break;
                     case OperationType.BulkInsertSqliteOperation:
                         MarshalCompletion(item.Completion, bulkInsertKey.PrepareToExecute(item.ParametersAsElements), commitResult);

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -78,7 +78,18 @@ namespace Akavache.Sqlite3
                 {
                     toProcess.Clear();
 
-                    using (await flushLock.LockAsync(shouldQuit.Token)) 
+                    IDisposable @lock = null;
+
+                    try
+                    {
+                        @lock = await flushLock.LockAsync(shouldQuit.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+
+                    using (@lock)
                     {
                         // NB: We special-case the first item because we want to 
                         // in the empty list case, we want to wait until we have an item.

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -132,8 +132,7 @@ namespace Akavache.Sqlite3
                 } 
                 catch (OperationCanceledException) { }
 
-                var newQueue = new BlockingCollection<OperationQueueItem>();
-                ProcessItems(CoalesceOperations(Interlocked.Exchange(ref operationQueue, newQueue).ToList()));
+                FlushInternal();
                 start = null;
             }));
         }

--- a/Akavache.Sqlite3/OperationQueue.cs
+++ b/Akavache.Sqlite3/OperationQueue.cs
@@ -233,10 +233,6 @@ namespace Akavache.Sqlite3
 
             Task.Run(async () =>
             {
-                // NB: We add a "DoNothing" operation so that the thread waiting
-                // on an item will always have one instead of waiting the full timeout
-                // before we can run the flush
-
                 IDisposable @lock = null;
                 try
                 {

--- a/Akavache.Sqlite3/OperationQueueCoalescing.cs
+++ b/Akavache.Sqlite3/OperationQueueCoalescing.cs
@@ -26,6 +26,9 @@ namespace Akavache.Sqlite3
 
         static internal List<OperationQueueItem> CoalesceOperations(List<OperationQueueItem> inputItems)
         {
+            // Happy path, nothing to coalesce.
+            if (inputItems.Count <= 1) return inputItems;
+
             var ret = new List<OperationQueueItem>();
 
             if (inputItems.Any(x => x.OperationType == OperationType.GetKeysSqliteOperation ||

--- a/Akavache.Sqlite3/Operations.cs
+++ b/Akavache.Sqlite3/Operations.cs
@@ -253,7 +253,6 @@ namespace Akavache.Sqlite3
     class InvalidateAllSqliteOperation : IPreparedSqliteOperation
     {
         SQLiteConnection conn;
-        IDisposable inner;
 
         public InvalidateAllSqliteOperation(SQLiteConnection conn)
         {

--- a/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
+++ b/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
@@ -299,7 +299,7 @@ namespace Akavache.Sqlite3
             {
                 versionNumber = Connection.ExecuteScalar<int>("SELECT Version from SchemaInfo ORDER BY Version DESC LIMIT 1");
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 shouldCreateSchemaTable = true;
             }

--- a/Akavache.Tests/Akavache.Tests.csproj
+++ b/Akavache.Tests/Akavache.Tests.csproj
@@ -103,6 +103,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncLockTests.cs" />
     <Compile Include="BlobCacheExtensionsFixture.cs" />
     <Compile Include="BlobCacheFixture.cs" />
     <Compile Include="BulkOperationsTest.cs" />

--- a/Akavache.Tests/AsyncLockTests.cs
+++ b/Akavache.Tests/AsyncLockTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Akavache.Sqlite3.Internal;
+using Xunit;
+
+namespace Akavache.Tests
+{
+    public class AsyncLockTests
+    {
+        [Fact]
+        public void HandlesCancellation()
+        {
+            var asyncLock = new AsyncLock();
+            var lockOne = asyncLock.LockAsync();
+
+            var cts = new CancellationTokenSource();
+            var lockTwo = asyncLock.LockAsync(cts.Token);
+
+            Assert.True(lockOne.IsCompleted);
+            Assert.Equal(TaskStatus.RanToCompletion, lockOne.Status);
+            Assert.NotNull(lockOne.Result);
+
+            Assert.False(lockTwo.IsCompleted);
+
+            cts.Cancel();
+
+            Assert.True(lockTwo.IsCompleted);
+            Assert.True(lockTwo.IsCanceled);
+
+            lockOne.Result.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
There's two race conditions in Flush and Vacuum. They try to pre-empt the main queue by scheduling a DoNothing operation but does so before waiting on the lock and the lock itself has no guarantees on ordering. To demonstrate, add a delay between the scheduling and the lock wait.

This PR addresses that but while I was investigating I also found a bug in AsyncLock which is fixed in this PR. The AsyncLock in Akavache was improved upon from the original in the hanselman blog post by making it cancellable. Unfortunately the task returned from LockAsync would complete regardless of the lock acquisition being cancelled or not, leading to a SemaphoreFullException when the "lock" was released. It also made flushLock unreliable a shutdown scenario.

There's context and explanations hidden in the commit messages that can be worth looking at while reviewing.