### PR TITLE
Allow UTC DateTimes to be forced.

### DIFF
--- a/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
+++ b/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
@@ -364,8 +364,14 @@ namespace Akavache.Sqlite3
             var settings = Locator.Current.GetService<JsonSerializerSettings>() ?? new JsonSerializerSettings();
             var serializer = JsonSerializer.Create(settings);
             var reader = new BsonReader(new MemoryStream(data));
+            var forcedDateTimeKind = BlobCache.ForcedDateTimeKind;
 
-            try 
+            if (forcedDateTimeKind.HasValue)
+            {
+                reader.DateTimeKindHandling = forcedDateTimeKind.Value;
+            }
+
+            try
             {
                 try
                 {

--- a/Akavache.Tests/BlobCacheFixture.cs
+++ b/Akavache.Tests/BlobCacheFixture.cs
@@ -280,6 +280,31 @@ namespace Akavache.Tests
                 }
             }
         }
+
+        [Fact]
+        public void DateTimeKindCanBeForced()
+        {
+            var before = BlobCache.ForcedDateTimeKind;
+            BlobCache.ForcedDateTimeKind = DateTimeKind.Utc;
+
+            try
+            {
+                string path;
+
+                using (Utility.WithEmptyDirectory(out path))
+                using (var fixture = CreateBlobCache(path))
+                {
+                    var value = DateTime.UtcNow;
+                    fixture.InsertObject("key", value).First();
+                    var result = fixture.GetObject<DateTime>("key").First();
+                    Assert.Equal(DateTimeKind.Utc, result.Kind);
+                }
+            }
+            finally
+            {
+                BlobCache.ForcedDateTimeKind = before;
+            }
+        }
     }
 
     public class InMemoryBlobCacheInterfaceFixture : BlobCacheInterfaceFixture

--- a/Akavache/Portable/BlobCache.cs
+++ b/Akavache/Portable/BlobCache.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using System.Reactive.Concurrency;
 using System.Reactive.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Bson;
 using System.Reactive;
 using System.Threading.Tasks;
 using System.Reflection;
@@ -123,6 +124,18 @@ namespace Akavache
         /// this cache will be lost when the application restarts.
         /// </summary>
         public static ISecureBlobCache InMemory { get; set; }
+
+        /// <summary>
+        /// Allows the DateTimeKind handling for BSON readers to be forced.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// By default, <see cref="BsonReader"/> uses a <see cref="DateTimeKind"/> of <see cref="DateTimeKind.Local"/> and <see cref="BsonWriter"/>
+        /// uses <see cref="DateTimeKind.Utc"/>. Thus, DateTimes are serialized as UTC but deserialized as local time. To force BSON readers to
+        /// use some other <c>DateTimeKind</c>, you can set this value.
+        /// </para>
+        /// </remarks>
+        public static DateTimeKind? ForcedDateTimeKind { get; set; }
 
         /// <summary>
         /// 

--- a/Akavache/Portable/InMemoryBlobCache.cs
+++ b/Akavache/Portable/InMemoryBlobCache.cs
@@ -269,6 +269,12 @@ namespace Akavache
             var settings = Locator.Current.GetService<JsonSerializerSettings>() ?? new JsonSerializerSettings();
             var serializer = JsonSerializer.Create(settings);
             var reader = new BsonReader(new MemoryStream(data));
+            var forcedDateTimeKind = BlobCache.ForcedDateTimeKind;
+
+            if (forcedDateTimeKind.HasValue)
+            {
+                reader.DateTimeKindHandling = forcedDateTimeKind.Value;
+            }
 
             try
             {


### PR DESCRIPTION
JSON.NET's BSON infrastructure writes DateTimes as UTC and reads them back as Local. There is a configuration property for this, but it exists only on the reader and writer - JsonSerializerSettings does not affect it. This PR adds the ability for client code to force a particular setting on JsonReader.DateTimeKindHandling.