### PR TITLE
Added CacheElement.Expiration index

### DIFF
--- a/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
+++ b/Akavache.Sqlite3/SqlitePersistentBlobCacheNext.cs
@@ -400,6 +400,7 @@ namespace Akavache.Sqlite3
 
         public string TypeName { get; set; }
         public byte[] Value { get; set; }
+        [Indexed()]
         public DateTime Expiration { get; set; }
         public DateTime CreatedAt { get; set; }
     }


### PR DESCRIPTION
Makes GetAllKeys() and others 100x faster when storing multi MB blobs. This also creates the index on existing databases, so no need to migrate or recreate.