### PR TITLE
use SQLitePCL.Batteries_V2.Init() instead of the original 

### DIFF
--- a/src/Akavache.Sqlite3/SQLite.cs
+++ b/src/Akavache.Sqlite3/SQLite.cs
@@ -221,7 +221,7 @@ namespace Akavache.Sqlite3.Internal
 		
 		static SQLiteConnection ()
 		{
-            SQLitePCL.Batteries.Init();
+            SQLitePCL.Batteries_V2.Init();
 
             if (_preserveDuringLinkMagic) {
 				var ti = new ColumnInfo ();


### PR DESCRIPTION
Batteries.Init().  the new one does exactly the same thing, but supports bait-and-switch across bundle types, which eases difficulties that can happen when using multiple libraries that use SQLitePCL.raw.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bug fix (more or less)

**What is the current behavior? (You can also link to an open issue here)**

call SQLitePCL.Batteries.Init()

**What is the new behavior (if this is a feature change)?**

call SQLitePCL.Batteries_V2.Init()

**Does this PR introduce a breaking change?**

no

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

