### PR TITLE
Fix a typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ added to support:
 
 Interacting with Akavache is primarily done through an object called
 `BlobCache`. At App startup, you must first set your app's name via
-`BlobCache.ApplicationName`. Ater setting your app's name, you're ready to save some data.
+`BlobCache.ApplicationName`. After setting your app's name, you're ready to save some data.
 
 #### Choose a location
 There are four build-in locations, that have some magic applied on some systems:


### PR DESCRIPTION
Change "Ater" to "After".
Fix #340.
