### PR TITLE
Document BlobCache.ForcedDateTimeKind in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,15 @@ You totally can. Just instantiate `SQLitePersistentBlobCache` or
 `SQLiteEncryptedBlobCache` instead - the static variables are there just to make it
 easier to get started.
 
+### DateTime/DateTimeOffset Considerations ###
 
+By default JSON.NET's BSON implementation writes `DateTime` as UTC and reads it back in local time.
+To override the reader's behavior you can set `BlobCache.ForcedDateTimeKind` as in the following example:
+
+```cs
+// Sets the reader to return DateTime/DateTimeOffset in UTC.
+BlobCache.ForcedDateTimeKind = DateTimeKind.Utc;
+```
 
 ## Basic Method Documentation
 


### PR DESCRIPTION
Documents ForcedDateTimeKind for reading back values.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs Update


**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**
Updated docs


**Does this PR introduce a breaking change?**
No


**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

**Other information**:
Documents changes that took place in #255 
