### PR TITLE
set UWP min version to 10.0.10586.0

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -8,6 +8,7 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
     <DefineConstants>$(DefineConstants);NETFX_CORE;XAML;WINDOWS_UWP</DefineConstants>
     <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;XAMARIN_MOBILE</DefineConstants>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
https://github.com/reactiveui/ReactiveUI/issues/1443

**What is the current behavior? (You can also link to an open issue here)**
Min version defaults to unsupported version


**What is the new behavior (if this is a feature change)?**
Min version is now set to

    <TargetPlatformMinVersion>10.0.10586.0</TargetPlatformMinVersion>


**Does this PR introduce a breaking change?**
It shouldn't

**Please check if the PR fulfills these requirements**
- [ ] The commit follows our guidelines: https://github.com/Akavache/Akavache/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

