### PR TITLE
fix: restrict system.reactive to 3.1.1 as min but never 4.x series

### DIFF
--- a/src/Akavache.Core/Akavache.Core.csproj
+++ b/src/Akavache.Core/Akavache.Core.csproj
@@ -12,7 +12,7 @@
     <None Include="Platforms\**\*.cs" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="Splat" Version="2.0.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
   
  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">

--- a/src/Akavache.Mobile/Akavache.Mobile.csproj
+++ b/src/Akavache.Mobile/Akavache.Mobile.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="reactiveui" Version="8.0.0-alpha0034" />
     <PackageReference Include="Splat" Version="2.0.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
+++ b/src/Akavache.Sqlite3/Akavache.Sqlite3.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Splat" Version="2.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="1.1.8" />
     <PackageReference Include="SQLitePCLRaw.core" Version="1.1.8" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Akavache.Tests/Akavache.Tests.csproj
+++ b/src/Akavache.Tests/Akavache.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refer to https://github.com/reactiveui/ReactiveUI/pull/1451 for backstory. 

**What is the new behavior (if this is a feature change)?**

Fixes https://github.com/reactiveui/ReactiveUI/pull/1413 by bypassing NuGet issue @ https://github.com/NuGet/Home/issues/5751

**Other information**:

System.Reactive v4.x and NuGet.exe needs more time to mature. We can remove these restrictions as a point release at a later point in time. Dynamic data is currently using `3.1.1` as min but is not clamped @RolandPheasant I strongly recommend that you do the same changes. Similar changes will be applied to Akavache, Refit, Punchclock, etc.
