### PR TITLE
housekeeping: bump next version to be 6.0

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,4 @@
+next-version: 6.0.0
 assembly-versioning-scheme: None
 branches:
   master:


### PR DESCRIPTION
This allows us to start shipping 6.0.0 to NuGet using the `alpha` prefix. This directive will be ignored after the tag/offical release of 6.0.0 (and should be removed)
